### PR TITLE
Add possibilit to define charset in HTTP-Request Content-Type

### DIFF
--- a/Private/InvokeAirTableApiCall.ps1
+++ b/Private/InvokeAirTableApiCall.ps1
@@ -28,7 +28,7 @@ function InvokeAirTableApiCall {
 			A string value representing the HTTP verb (method) to send to the API. This defaults to using GET.
    
    		.PARAMETER CharSet
-     			Define charset like utf-8
+     			A string value representing charset like utf-8, which is used for the http-request
 			Possible charsets:
 			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	

--- a/Private/InvokeAirTableApiCall.ps1
+++ b/Private/InvokeAirTableApiCall.ps1
@@ -28,7 +28,7 @@ function InvokeAirTableApiCall {
 			A string value representing the HTTP verb (method) to send to the API. This defaults to using GET.
    
    		.PARAMETER CharSet
-     			A string value representing charset like utf-8, which is used for the http-request
+     			A string value representing charset like utf-8, which is used for the http-request.
 			Possible charsets:
 			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	

--- a/Private/InvokeAirTableApiCall.ps1
+++ b/Private/InvokeAirTableApiCall.ps1
@@ -13,6 +13,11 @@ function InvokeAirTableApiCall {
 
 			Queries the AirTable URI and passes the HTTP body to the API using the POST method.
 
+     		.EXAMPLE
+			PS> InvokeAirTableApiCall -Uri 'https://api.airtable.com/v0/Fruit' -HttpBody @{ filterByFormula = "{Name}='Apple'" } -Method POST -CharSet 'utf-8'
+
+			Queries the AirTable URI and passes the HTTP body to the API using the POST method with charset 'utf-8'
+
 		.PARAMETER Uri
 			A string value representing the API endpoint URI.
 
@@ -21,6 +26,11 @@ function InvokeAirTableApiCall {
 
 		.PARAMETER Method
 			A string value representing the HTTP verb (method) to send to the API. This defaults to using GET.
+   
+   		.PARAMETER CharSet
+     			Define charset like utf-8
+			Possible charsets:
+			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	
 	#>
     [OutputType('pscustomobject')]
@@ -34,6 +44,10 @@ function InvokeAirTableApiCall {
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [hashtable]$HttpBody,
+
+ 	[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CharSet,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -66,7 +80,12 @@ function InvokeAirTableApiCall {
                 break
             }
             { $_ -in 'PATCH', 'POST', 'DELETE' } {
-                $invRestParams.ContentType = 'application/json'
+	    	if($CharSet)
+                	$invRestParams.ContentType = 'application/json; charset=' + $CharSet
+		 }
+   		else{
+     			$invRestParams.ContentType = 'application/json'
+		}
                 if ($PSBoundParameters.ContainsKey('HttpBody')) {
                     $invRestParams.Body = (ConvertTo-Json $HttpBody)
                 }

--- a/Public/Find-Record.ps1
+++ b/Public/Find-Record.ps1
@@ -26,6 +26,11 @@ function Find-Record {
 
 		.PARAMETER View
 			An optional string parameter representing a table view to limit results to.
+
+   		.PARAMETER CharSet
+     			A string value representing charset like utf-8, which is used for the http-request.
+			Possible charsets:
+			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	
 	#>
     [OutputType('pscustomobject')]
@@ -61,6 +66,10 @@ function Find-Record {
         [ValidateNotNullOrEmpty()]
         [string]$SortField,
 
+  	[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CharSet,
+
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$PersonalAccessToken
@@ -94,6 +103,9 @@ function Find-Record {
         if ($PSBoundParameters.ContainsKey('SortDirection')) {
             $httpBody['sort[0][direction]'] = $SortDirection
         }
+    }
+    if($CharSet){
+  	$invParams.CharSet = $CharSet
     }
     if ($httpBody.Keys -gt 0) {
         $invParams.HttpBody = $httpBody

--- a/Public/New-Record.ps1
+++ b/Public/New-Record.ps1
@@ -17,6 +17,11 @@ function New-Record {
 		.PARAMETER Fields
 			A hashtable value representing all of the new record's fields. Each key in the hashtable is the
 			field name and each corresponding value is the value to update the field to.
+   
+   		.PARAMETER CharSet
+     			A string value representing charset like utf-8, which is used for the http-request
+			Possible charsets:
+			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	
 	#>
     [OutputType('void')]
@@ -35,6 +40,10 @@ function New-Record {
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Fields,
+
+ 	[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CharSet,
 
         [switch]$PassThru,
 
@@ -56,7 +65,10 @@ function New-Record {
         HttpBody = @{
 	    'fields' = $Fields
 	    'typecast' = $True
-	}
+	}	
+    }
+    if($CharSet){
+  	$invParams.CharSet = $CharSet
     }
     if ($PSBoundParameters.ContainsKey('PersonalAccessToken')) {
         $invParams.PersonalAccessToken = $PersonalAccessToken

--- a/Public/Update-Record.ps1
+++ b/Public/Update-Record.ps1
@@ -28,6 +28,11 @@ function Update-Record {
 		.PARAMETER Fields
 			A hashtable value representing all of the record's fields to update. Each key in the hashtable is the
 			field name and each corresponding value is the value to update the field to.
+
+   		.PARAMETER CharSet
+     			A string value representing charset like utf-8, which is used for the http-request.
+			Possible charsets:
+			https://www.iana.org/assignments/character-sets/character-sets.xhtml
 	
 	#>
     [OutputType('void')]
@@ -55,6 +60,10 @@ function Update-Record {
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Fields,
+
+ 	[Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$CharSet,
 
         [switch]$PassThru,
 
@@ -88,6 +97,9 @@ function Update-Record {
         if ($PSBoundParameters.ContainsKey('PersonalAccessToken')) {
             $invParams.PersonalAccessToken = $PersonalAccessToken
         }
+	if($CharSet){
+            $invParams.CharSet = $CharSet
+    	}
 
         $targetMsg = "AirTable Record ID [$($InputObject.'Record ID')] in table [$($InputObject.Table)]"
         $actionMsg = "Update fields [$($Fields.Keys -join ',')] to [$($Fields.Values -join ',')]"


### PR DESCRIPTION
I have noticed that German umlauts are not always written correctly in Airtable. On a machine with an English locale, the umlauts could not be sent correctly to Airtable.
If the locale is German, then it works.

As a solution, the charset can be specified in the ContentType.
For this reason I have written this patch, which makes it possible to define the charset for the HTTP request for New-Record, Update-Record and Find-Record.